### PR TITLE
un-marketing fratures-article

### DIFF
--- a/features.md
+++ b/features.md
@@ -34,7 +34,7 @@ Once a Fuse project looks and feels right, the difference between prototype and 
 
 Fuse projects are written in plain-text source code. This lets you use whatever text editors and design tools you prefer, with extra convenience features available if your chosen editor leverages Fuse's open [plugin API](https://fuse-open.github.io/docs/technical-corner/fuse-protocol). Mature plugins offering problem solving, code completion and project management already exist for [Sublime Text]({{ site.baseurl }}/docs/basics/installation/sublime-plugin.html), [Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=iGN97.fuse-vscode) and [Atom]({{ site.baseurl }}/docs/basics/installation/atom-plugin.html).
 
-### iOS, Android and .NET/Mono
+### iOS, Android and .NET
 
 With a shared codebase in UX Markup and JavaScript applications can be deployed to both iOS and Android as well as Windows and OSX. Further native platform features can be accessed by adding Objective-C, Swift, C# or Java code directly to your project to implement the hooks that allow them to be used (and reused) from script and markup.
 


### PR DESCRIPTION
The features-article was lifted straight from fusetools.com, and that
version was pretty marketing-heavy. This style is less fitting for an
open-source project, so let's rewrite it to be a lot more fact-oriented.