### PR TITLE
Fix Fuse Studio urls

### DIFF
--- a/downloads.md
+++ b/downloads.md
@@ -5,7 +5,7 @@ permalink: /downloads/
 ---
 
 You can download the latest installer of Fuse
-[here](https://github.com/fuse-open/Fuse/releases).
+[here](https://github.com/fuse-open/fuse-studio/releases).
 
 Old installers from before open-sourcing Fuse can be downloaded
 [here](https://github.com/fusetools/fuse-releases/releases).

--- a/source.md
+++ b/source.md
@@ -36,6 +36,6 @@ Fuselibs.
 [1]: https://github.com/fuse-open/uno
 [2]: https://en.wikipedia.org/wiki/C_Sharp_(programming_language)
 [3]: https://github.com/fusetools/fuselibs-public
-[4]: https://github.com/fuse-open/Fuse
+[4]: https://github.com/fuse-open/fuse-studio
 [5]: https://github.com/fusetools/fuselibs-public/blob/master/README.md#fuse
 [6]: https://github.com/fuse-open/uno/blob/master/Documentation/Configuration.md#standard-library


### PR DESCRIPTION
Migrate to new fuse-studio repo url