### PR TITLE
link to fuse-open version of the examples

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,7 +14,7 @@ markdown: kramdown
 theme: minima
 header_pages:
   - features.md
-  - url: https://examples.fusetools.com/
+  - url: /examples/
     title: Examples
   - showcases.md
   - url: /docs/


### PR DESCRIPTION
We now have [our own version](https://fuse-open.github.io/examples) of [examples.fusetools.com](https://examples.fusetools.com/), so let's prefer that one instead, huh? :)