### PR TITLE
No feed meta

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,0 +1,11 @@
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  {%- seo -%}
+  <link rel="stylesheet" href="{{ "/assets/main.css" | relative_url }}">
+  {%- feed_meta -%}
+  {%- if jekyll.environment == 'production' and site.google_analytics -%}
+    {%- include google-analytics.html -%}
+  {%- endif -%}
+</head>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,7 +4,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   {%- seo -%}
   <link rel="stylesheet" href="{{ "/assets/main.css" | relative_url }}">
-  {%- feed_meta -%}
   {%- if jekyll.environment == 'production' and site.google_analytics -%}
     {%- include google-analytics.html -%}
   {%- endif -%}


### PR DESCRIPTION
We're not doing a blog, so having a feed.xml-reference is just
pointless. Besides, we don't actually enable the plugin, so the
feed.xml-file isn't even generated.

Sadly, minima doesn't seem to have any way of disabling its
jekyll-feed usage, so we're going to have to for this file and do
it ourselves. Oh well.
   
This works around jekyll/minima#98.