### PR TITLE
Fix source-code link

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,3 +24,4 @@ gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem "wdm", "~> 0.1.0" if Gem.win_platform?
 
 gem 'jekyll-sitemap'
+gem 'jekyll-redirect-from'

--- a/_config.yml
+++ b/_config.yml
@@ -31,3 +31,4 @@ exclude:
 
 plugins:
   - jekyll-sitemap
+  - jekyll-redirect-from

--- a/source.md
+++ b/source.md
@@ -2,6 +2,8 @@
 layout: page
 title: Source
 permalink: /source/
+redirect_from:
+  - /source-code/
 ---
 Building from source code requires some more knowledge about the project,
 as it's split in multiple components. Which component you want to tinker


### PR DESCRIPTION
An early draft of this page was named "source-code" instead of
"source". Sadly, this link has made it out into the wild.
    
So let's forward the old link to here.