### PR TITLE
downloads: add link to 1.9 pre-release download-location

### DIFF
--- a/downloads.md
+++ b/downloads.md
@@ -4,5 +4,8 @@ title: Downloads
 permalink: /downloads/
 ---
 
-You can download the latest installer of Fuse
+You can download the 1.9 pre-release installer for Fuse
+[here](https://github.com/fuse-open/fuse-studio/releases).
+
+Fuse 1.8 (and older) can be downloaded
 [here](https://github.com/fusetools/fuse-releases/releases).


### PR DESCRIPTION
Now that we actually have something here, we can add the link. But
unlike last time, let's word this a bit more carefully.