### PR TITLE
add forums/contact-redirect

### DIFF
--- a/contact.md
+++ b/contact.md
@@ -1,0 +1,6 @@
+---
+layout: page
+title: Contact
+permalink: /contact/
+redirect_to: https://www.fusetools.com/contact
+---

--- a/forums.md
+++ b/forums.md
@@ -1,0 +1,7 @@
+---
+layout: page
+title: Forums
+permalink: /community/forums
+redirect_from: /forums
+redirect_to: https://forums.fusetools.com/
+---


### PR DESCRIPTION
There has been some links out in the wild pointing to these invalid
URLs, so let's add a forward here to fix them if they were ever
replicated somewhere else.

It's nice to have somewhere we can redirect if we ever switch
forum-URL away from fusetools.com in the future, anyway.