### PR TITLE
footer: add edit-page link to all pages

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -10,6 +10,7 @@
         </ul>
       </div>
       <div class="col-md">
+        <p><i class="fas fa-edit mr-2"></i><a href="https://github.com/fuse-open/fuse-open.github.io/blob/master/{{ page.path }}">Edit this page on Github</a></p>
         <p>{{ site.description | escape }}</p>
       </div>
     </div>


### PR DESCRIPTION
It's very useful for the community to know that they can propose
edits to the website, so let's make this relatively easy to discover,
by adding a link to the footer.