### PR TITLE
Hide entering details

### DIFF
--- a/logo-contest.md
+++ b/logo-contest.md
@@ -31,6 +31,11 @@ contribute and submit.
 - Optional: [SVG](https://en.wikipedia.org/wiki/Scalable_Vector_Graphics) fonts
   are preferred, as they are easier to rescale.
 
+## Deadline
+
+The deadline is Sunday 1st of July 2018. Please submit your entries before
+then.
+
 ## How to enter
 
 <div class="alert alert-warning" role="alert">
@@ -71,11 +76,6 @@ in the following format:
 You can see an example-submission [here](https://github.com/kusma/fuse-open.github.io/compare/logo-contest...example-submission).
 
 </div>
-
-## Deadline
-
-The deadline is Sunday 1st of July 2018. Please submit your entries before
-then.
 
 ## Submissions
 

--- a/logo-contest.md
+++ b/logo-contest.md
@@ -34,9 +34,15 @@ contribute and submit.
 ## How to enter
 
 <div class="alert alert-warning" role="alert">
+  <p>
   We're currently past the submission deadline, so no more submissions will be
   accepted.
+  </p>
+  <a class="btn btn-warning" data-toggle="collapse" href="#howToEnter" role="button" aria-expanded="false" aria-controls="howToEnter">
+      Show details
+  </a>
 </div>
+<div class="collapse" id="howToEnter" markdown="1">
 
 ### By E-Mail
 
@@ -63,6 +69,8 @@ in the following format:
 ```
 
 You can see an example-submission [here](https://github.com/kusma/fuse-open.github.io/compare/logo-contest...example-submission).
+
+</div>
 
 ## Deadline
 


### PR DESCRIPTION
This page is a bit cluttered, thanks to some mostly irrelevant information. But I'd like to keep the information for those interested, so let's just hide it by default.

While we're at it, let's reorder the content a bit to read a bit more naturally.