### PR TITLE
Fix duplicated titles on showcase detail page

### DIFF
--- a/_layouts/showcase.html
+++ b/_layouts/showcase.html
@@ -3,10 +3,6 @@ layout: page
 ---
 
 <div class="showcase">
-  {%- if page.title -%}
-    <h1 class="page-heading">{{ page.title }}</h1>
-  {%- endif -%}
-
   {%- if page.screenshots -%}
     <img src="{{ page.screenshots }}" alt="Criminal Mind">
   {%- endif -%}


### PR DESCRIPTION
There are two titles on showcase.html layout and page.html layout
which is the base layout of showcase.html.
Since page.html layout is also used to other layouts, let's delete
title part on showcase.html layout to fix duplicated titles.