### PR TITLE
Fix broken links

### DIFF
--- a/forums.md
+++ b/forums.md
@@ -2,6 +2,6 @@
 layout: page
 title: Forums
 permalink: /forums/
-redirect_from: /forums
+redirect_from: /community/forums/
 redirect_to: https://forums.fusetools.com/
 ---

--- a/get_started.md
+++ b/get_started.md
@@ -2,7 +2,9 @@
 layout: page
 title: Get Started
 permalink: /get-started/
-redirect_from: /source-code/
+redirect_from:
+  - /source-code/
+  - /downloads/
 ---
 Building from source code requires some more knowledge about the project,
 as it's split in multiple components. Which component you want to tinker

--- a/index.md
+++ b/index.md
@@ -1,3 +1,6 @@
 ---
 layout: home
+redirect_from:
+  - /contact/
+  - /features/
 ---

--- a/logo-contest.md
+++ b/logo-contest.md
@@ -1,0 +1,6 @@
+---
+layout: page
+title: Logo Contest
+permalink: /logo-contest/
+redirect_to: https://github.com/fuse-open/fuse-open.github.io/tree/b40cdb6693514e1270e06c394f4914a20a0ad156/assets/images/logo-contest
+---


### PR DESCRIPTION
When updating the website to the new design, we accidentally broke a few links. Here's a lazy attempt at restoring them in the minimal way, simply by redirecting.