### PR TITLE
download-example: temporarily freeze reference for examples

### DIFF
--- a/assets/download-example.js
+++ b/assets/download-example.js
@@ -1,7 +1,7 @@
 function downloadExample(element, example) {
   var prefix = 'https://api.github.com/repos/fuse-open/examples/contents/'
   var dir = 'examples/' + example + '/code/'
-  var url = prefix + dir + '?ref=master'
+  var url = prefix + dir + '?ref=98882751697248720484fe45a8f089aeb492d97e'
 
   function github_subdir(url) {
     return fetch(url).then(response => {


### PR DESCRIPTION
I'm about to restructure the examples-repo, and to avoid temporarily
breaking the example-downloads, let's freeze the ref we're pointing to
until the new structure is in place and we can atomically update to the
new master.